### PR TITLE
RetryUtil.java #195 行

### DIFF
--- a/common/src/main/java/com/alibaba/datax/common/util/RetryUtil.java
+++ b/common/src/main/java/com/alibaba/datax/common/util/RetryUtil.java
@@ -192,7 +192,10 @@ public final class RetryUtil {
         protected <T> T call(Callable<T> callable) throws Exception {
             Future<T> future = executor.submit(callable);
             try {
-                return future.get(timeoutMs, TimeUnit.MILLISECONDS);
+                //return future.get(timeoutMs, TimeUnit.MILLISECONDS);
+                T ret = future.get(timeoutMs, TimeUnit.MILLISECONDS);
+                executor.shutdown();
+                return ret;
             } catch (Exception e) {
                 LOG.warn("Try once failed", e);
                 throw e;


### PR DESCRIPTION
异步重试执行成功之后，如果没有这句executor.shutdown()。则导致此线程池还在后台运行。
我单独将RetryUtil.java提取到单独的项目中测试发现，即使异步重试执行成功后，线程池还在占用主线程执行时间。
加了executor.shutdown()这句之后，程序正常退出。